### PR TITLE
Add feauture to avoid exclusive lock on macos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ no-keyboard-test = []
 default = ["serde-serialize"]
 
 [dependencies]
-hidapi = "1.2.5"
+hidapi = { version = "1.2.5", features = ["macos-shared-device"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
otherwise, on macos the opening the same device multiple times won't work and the app quits with "NoKeyboardFound"